### PR TITLE
+Bugfix: Temperature below 0 overflows

### DIFF
--- a/IOSThingyLibrary/Classes/Peripheral/ThingyPeripheral.swift
+++ b/IOSThingyLibrary/Classes/Peripheral/ThingyPeripheral.swift
@@ -443,7 +443,7 @@ public class ThingyPeripheral: NSObject, CBPeripheralDelegate {
         }
         // Save the notification callback. This may overwrite the old one if such existed
         valueCallbackHandlers[getTemperatureCharacteristicUUID()] = { (temperatureData) -> (Void) in
-            let digit        = Int8(temperatureData[0])
+            let digit        = Int8(truncatingBitPattern: Int(temperatureData[0]))
             let remainder    = UInt8(temperatureData[1])
             var temp = Float(digit)
             temp += Float(remainder) / 100


### PR DESCRIPTION
Temperature readings were parsed into an Int8 and caused an overflow when first bit was set, this is now resolved with this fix