### PR TITLE
Fix for building on XCode 13

### DIFF
--- a/IOSThingyLibrary/Classes/Services/SoundService/ThingySoundService.swift
+++ b/IOSThingyLibrary/Classes/Services/SoundService/ThingySoundService.swift
@@ -226,7 +226,10 @@ internal class ThingySoundService: ThingyService {
         let mtu: Int
         if #available(iOS 9.0, *) {
             // Either MTU or DLE will be used
-            mtu = baseService.peripheral?.maximumWriteValueLength(for: .withoutResponse) ?? 0
+            guard let _mtu = baseService.peripheral?.maximumWriteValueLength(for: .withoutResponse) else {
+                return
+            }
+            mtu = _mtu
         } else {
             // MTU and DLE are not supported
             mtu = 20

--- a/IOSThingyLibrary/Classes/Services/SoundService/ThingySoundService.swift
+++ b/IOSThingyLibrary/Classes/Services/SoundService/ThingySoundService.swift
@@ -226,7 +226,7 @@ internal class ThingySoundService: ThingyService {
         let mtu: Int
         if #available(iOS 9.0, *) {
             // Either MTU or DLE will be used
-            mtu = baseService.peripheral.maximumWriteValueLength(for: .withoutResponse)
+            mtu = baseService.peripheral?.maximumWriteValueLength(for: .withoutResponse) ?? 0
         } else {
             // MTU and DLE are not supported
             mtu = 20

--- a/IOSThingyLibrary/Classes/Services/ThingyService/Characteristics/ThingyCharacteristic.swift
+++ b/IOSThingyLibrary/Classes/Services/ThingyService/Characteristics/ThingyCharacteristic.swift
@@ -63,7 +63,7 @@ internal class ThingyCharacteristic: NSObject {
     //MARK: - Implementation
     internal func writeValue(withData data: Data?, type: CBCharacteristicWriteType = .withResponse) {
         if data != nil {
-            characteristic.service.peripheral.writeValue(data!, for: characteristic, type: type)
+            characteristic.service?.peripheral?.writeValue(data!, for: characteristic, type: type)
         } else {
             print("Warning: No data to write to characteristic, ignoring call")
         }
@@ -78,11 +78,11 @@ internal class ThingyCharacteristic: NSObject {
     }
 
     internal func startNotifications() {
-        characteristic.service.peripheral.setNotifyValue(true, for: characteristic)
+        characteristic.service?.peripheral?.setNotifyValue(true, for: characteristic)
     }
 
     internal func stopNotifications() {
-        characteristic.service.peripheral.setNotifyValue(false, for: characteristic)
+        characteristic.service?.peripheral?.setNotifyValue(false, for: characteristic)
     }
     
     //MARK: - Convenience


### PR DESCRIPTION
This commit deals with Apple's update which makes the peripheral on CBService optional .

It requires the update on the `develop` branch of IOS-DFU-Library to be pushed to cocoapods, and will require the dependency version of this library's podspec being updated to match it. The PR has already been merged, but the update hasn't been released on DFU > https://github.com/NordicSemiconductor/IOS-DFU-Library/pull/455